### PR TITLE
Feature/version3

### DIFF
--- a/examples/node.js/app.js
+++ b/examples/node.js/app.js
@@ -34,6 +34,7 @@ const callbackReload = require('./routes/sdk-callback-reload.js');
 const androidIntentCallback = require('./routes/android-intent-callback.js');
 const iosUniversalLinkCallback = require('./routes/ios-universal-link-callback.js');
 const payerTokens = require('./routes/payer-tokens.js');
+const payerExpand = require('./routes/payer-expand.js');
 const patchPayerToken = require('./routes/patch-payer-token.js');
 
 // Specify our routes
@@ -54,6 +55,8 @@ app.get(constants.androidIntentCallbackPath, celebrate({ query: androidIntentCal
   androidIntentCallback.route);
 app.get(constants.iosUniversalLinkCallbackPath, celebrate({ query: iosUniversalLinkCallback.schema }),
   iosUniversalLinkCallback.route);
+
+app.get('/payer/:psp/paymentorders/:ref', payerExpand.route);
 
 // Handle the errors from Celebrate. Must be defined after the routes.
 app.use(celebrateProblems);

--- a/examples/node.js/routes/payer-expand.js
+++ b/examples/node.js/routes/payer-expand.js
@@ -21,67 +21,11 @@ module.exports.route = async (req, res) => {
         const response = await get(`/${psp}/paymentorders/${payerRef}?$expand=payer`);
 
         // Your implementation should at this point probably calculate shipping costs and tell the client how to show this to the user, and present alternative shipping methods.
+
         res.status(200).send().end();
     } catch (e) {
-        console.log('Failed to get payer tests');
+        console.log('Failed to expland payer');
         console.log(e);
         sendError(res, e);
     }
 };
-
-/*
-Remove debug info when done:
-{"paymentOrder":
-    {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178","created":"2022-02-15T14:31:41.2140660Z","updated":"2022-02-15T14:31:41.4447836Z","operation":"Purchase","status":"Initialized","currency":"SEK","amount":1000,"vatAmount":200,"description":"Order 12345678","initiatingSystemUserAgent":"SwedbankPaySDK-Android/1.0","language":"en-US","availableInstruments":["CreditCard","Invoice-PayExFinancingSe","Invoice-PayMonthlyInvoiceSe","CarPay","Swish","CreditAccount"],"implementation":"Starter","integration":"","instrumentMode":false,"guestMode":true,"orderItems":
-        {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/orderitems"},
-        "urls":
-            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/urls"},
-        "payeeInfo":
-            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/payeeinfo"},
-        "payer":
-            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/payers"},
-            "history":
-            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/history"},
-            "failed":
-            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/failed"},
-        "aborted":
-            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/aborted"},
-        "paid":
-            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/paid"},
-        "cancelled":
-            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/cancelled"},
-        "financialTransactions":
-            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/financialtransactions"}
-        ,"failedAttempts":
-            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/failedattempts"}
-        ,"metadata":
-            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/metadata"}
-        },"operations":
-            [
-                {"method":"PATCH","href":"https://api.externalintegration.payex.com/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178","rel":"update-order","contentType":"application/json"},
-                {"method":"PATCH","href":"https://api.externalintegration.payex.com/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178","rel":"abort","contentType":"application/json"},
-                {"method":"GET","href":"https://ecom.externalintegration.payex.com/checkout/5bb472e127cdc20c748d9b032c7a2c3ccb0854ea86fba17aea2a45135ed42a69","rel":"redirect-checkout","contentType":"text/html"},
-                {"method":"GET","href":"https://ecom.externalintegration.payex.com/checkout/core/client/checkout/5bb472e127cdc20c748d9b032c7a2c3ccb0854ea86fba17aea2a45135ed42a69?culture=en-US","rel":"view-checkout","contentType":"application/javascript"}
-            ]
-        }
-        //get: psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178?$expand=payer
-
-        second attempt:
-
-        {"paymentOrder":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6","created":"2022-02-15T20:13:36.8551064Z","updated":"2022-02-15T20:13:36.9723316Z","operation":"Purchase","status":"Initialized","currency":"SEK","amount":1000,"vatAmount":200,"description":"Order 12345678","initiatingSystemUserAgent":"SwedbankPaySDK-Android/1.0","language":"en-US","availableInstruments":["CreditCard","Invoice-PayExFinancingSe","Invoice-PayMonthlyInvoiceSe","CarPay","Swish","CreditAccount"],"implementation":"Starter","integration":"","instrumentMode":false,"guestMode":true,"orderItems":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/orderitems"},"urls":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/urls"},"payeeInfo":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/payeeinfo"},"payer":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/payers"},"history":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/history"},"failed":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/failed"},"aborted":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/aborted"},"paid":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/paid"},"cancelled":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/cancelled"},"financialTransactions":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/financialtransactions"},"failedAttempts":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/failedattempts"},"metadata":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/metadata"}},"operations":[{"method":"PATCH","href":"https://api.externalintegration.payex.com/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6","rel":"update-order","contentType":"application/json"},{"method":"PATCH","href":"https://api.externalintegration.payex.com/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6","rel":"abort","contentType":"application/json"},{"method":"GET","href":"https://ecom.externalintegration.payex.com/checkout/core/client/checkout/7b8c32e24d327ed8446fcdf257c36d55fea8e9dcec3ad7359db75bebdf5b73b8?culture=en-US","rel":"view-checkout","contentType":"application/javascript"}]}
-
-using get: /psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6?$expand=payer
-gives:
-
-payer: {
-      id: '/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/payers',
-      reference: '6ee913a1-85ef-4aed-ada2-8e9f5850931d',
-      name: 'Förnamn Efternamn',
-      email: 'kent@hej.ee',
-      msisdn: '+46733123123',
-      hashedFields: [Object],
-      shippingAddress: [Object],
-      device: [Object]
-    },
-
-*/

--- a/examples/node.js/routes/payer-expand.js
+++ b/examples/node.js/routes/payer-expand.js
@@ -21,6 +21,7 @@ module.exports.route = async (req, res) => {
         const response = await get(`/${psp}/paymentorders/${payerRef}?$expand=payer`);
 
         // Your implementation should at this point probably calculate shipping costs and tell the client how to show this to the user, and present alternative shipping methods.
+        // In this example, we don't send in anything.
 
         res.status(200).send().end();
     } catch (e) {

--- a/examples/node.js/routes/payer-expand.js
+++ b/examples/node.js/routes/payer-expand.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const { get, sendError } = require('../util/networking.js');
+const { makeUnauthorizedProblem } = require('../util/problems.js');
+
+async function authorize(req) {
+    // To allow, add "allowGetPayerOwnedPaymentTokens": true to appconfig.json
+    // A real implementation must do access control to only
+    // allow a user to access their own tokens.
+    if (!global.config.allowGetPayerOwnedPaymentTokens) {
+        throw makeUnauthorizedProblem();
+    }
+}
+
+module.exports.route = async (req, res) => {
+    try {
+        //This is sensative data but can only be accessed by the client, additional authorizations shouldn't be needed at this point.
+        //await authorize(req);
+        const payerRef = req.params.ref;
+        const psp = req.params.psp; //This is not likely to change, but in case I allow some flexibility here.
+        const response = await get(`/${psp}/paymentorders/${payerRef}?$expand=payer`);
+
+        // Your implementation should at this point probably calculate shipping costs and tell the client how to show this to the user, and present alternative shipping methods.
+        res.status(200).send().end();
+    } catch (e) {
+        console.log('Failed to get payer tests');
+        console.log(e);
+        sendError(res, e);
+    }
+};
+
+/*
+Remove debug info when done:
+{"paymentOrder":
+    {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178","created":"2022-02-15T14:31:41.2140660Z","updated":"2022-02-15T14:31:41.4447836Z","operation":"Purchase","status":"Initialized","currency":"SEK","amount":1000,"vatAmount":200,"description":"Order 12345678","initiatingSystemUserAgent":"SwedbankPaySDK-Android/1.0","language":"en-US","availableInstruments":["CreditCard","Invoice-PayExFinancingSe","Invoice-PayMonthlyInvoiceSe","CarPay","Swish","CreditAccount"],"implementation":"Starter","integration":"","instrumentMode":false,"guestMode":true,"orderItems":
+        {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/orderitems"},
+        "urls":
+            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/urls"},
+        "payeeInfo":
+            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/payeeinfo"},
+        "payer":
+            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/payers"},
+            "history":
+            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/history"},
+            "failed":
+            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/failed"},
+        "aborted":
+            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/aborted"},
+        "paid":
+            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/paid"},
+        "cancelled":
+            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/cancelled"},
+        "financialTransactions":
+            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/financialtransactions"}
+        ,"failedAttempts":
+            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/failedattempts"}
+        ,"metadata":
+            {"id":"/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178/metadata"}
+        },"operations":
+            [
+                {"method":"PATCH","href":"https://api.externalintegration.payex.com/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178","rel":"update-order","contentType":"application/json"},
+                {"method":"PATCH","href":"https://api.externalintegration.payex.com/psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178","rel":"abort","contentType":"application/json"},
+                {"method":"GET","href":"https://ecom.externalintegration.payex.com/checkout/5bb472e127cdc20c748d9b032c7a2c3ccb0854ea86fba17aea2a45135ed42a69","rel":"redirect-checkout","contentType":"text/html"},
+                {"method":"GET","href":"https://ecom.externalintegration.payex.com/checkout/core/client/checkout/5bb472e127cdc20c748d9b032c7a2c3ccb0854ea86fba17aea2a45135ed42a69?culture=en-US","rel":"view-checkout","contentType":"application/javascript"}
+            ]
+        }
+        //get: psp/paymentorders/62088122-3d87-4636-2fb8-08d9ec88b178?$expand=payer
+
+        second attempt:
+
+        {"paymentOrder":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6","created":"2022-02-15T20:13:36.8551064Z","updated":"2022-02-15T20:13:36.9723316Z","operation":"Purchase","status":"Initialized","currency":"SEK","amount":1000,"vatAmount":200,"description":"Order 12345678","initiatingSystemUserAgent":"SwedbankPaySDK-Android/1.0","language":"en-US","availableInstruments":["CreditCard","Invoice-PayExFinancingSe","Invoice-PayMonthlyInvoiceSe","CarPay","Swish","CreditAccount"],"implementation":"Starter","integration":"","instrumentMode":false,"guestMode":true,"orderItems":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/orderitems"},"urls":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/urls"},"payeeInfo":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/payeeinfo"},"payer":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/payers"},"history":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/history"},"failed":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/failed"},"aborted":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/aborted"},"paid":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/paid"},"cancelled":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/cancelled"},"financialTransactions":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/financialtransactions"},"failedAttempts":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/failedattempts"},"metadata":{"id":"/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/metadata"}},"operations":[{"method":"PATCH","href":"https://api.externalintegration.payex.com/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6","rel":"update-order","contentType":"application/json"},{"method":"PATCH","href":"https://api.externalintegration.payex.com/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6","rel":"abort","contentType":"application/json"},{"method":"GET","href":"https://ecom.externalintegration.payex.com/checkout/core/client/checkout/7b8c32e24d327ed8446fcdf257c36d55fea8e9dcec3ad7359db75bebdf5b73b8?culture=en-US","rel":"view-checkout","contentType":"application/javascript"}]}
+
+using get: /psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6?$expand=payer
+gives:
+
+payer: {
+      id: '/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6/payers',
+      reference: '6ee913a1-85ef-4aed-ada2-8e9f5850931d',
+      name: 'Förnamn Efternamn',
+      email: 'kent@hej.ee',
+      msisdn: '+46733123123',
+      hashedFields: [Object],
+      shippingAddress: [Object],
+      device: [Object]
+    },
+
+*/

--- a/examples/node.js/tests/paymentorder.test.js
+++ b/examples/node.js/tests/paymentorder.test.js
@@ -22,6 +22,27 @@ function checkCredentials(res) {
   chai.assert(res.status != 401, "Getting 401, is the credentials missing?\n" + res.text)
 }
 
+describe('Expand payer in a v3 payment order', () => {
+  
+  it('Payer should be expanded', (done) => {
+
+    chai.request(app)
+      .get("/payer/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6") 
+      .set(headers)
+      .end((err, res) => {
+
+        //console.log(res.body.paymentOrder.payer)
+        checkCredentials(res)
+
+        res.should.have.status(200);
+        res.body.should.be.a('object');
+        done();
+     });
+    
+  })
+  .timeout(15 * 1000);  //usually it never takes more than one second
+});
+
 describe('Post PaymentOrder v3', () => {
   
   it('Payment order should be accepted', (done) => {


### PR DESCRIPTION
Adding a method to expand the payer info of a paymentOrder, after a user has checked in we need it to get address, email and similar info.