### PR TITLE
Better UserAgent handling to report SDK version

### DIFF
--- a/examples/node.js/agent_middleware.js
+++ b/examples/node.js/agent_middleware.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/**
+ * User-agent middleware. We need to supply the SDK version to the system in every request. 
+ *
+ * @param {object} req our Express request object
+ * @param {object} res our Express response object
+ * @param {object} next our next Express route handler
+ */
+const agent = (req, res, next) => {
+
+    let userAgent = req.headers["user-agent"] || req.headers["User-Agent"];
+    if (userAgent) {
+        global.userAgent = userAgent;
+    }
+    next();
+};
+
+module.exports = agent;

--- a/examples/node.js/app.js
+++ b/examples/node.js/app.js
@@ -19,6 +19,8 @@ global.database = new Database();
 // Import middlewares
 const auth = require('./auth_middleware.js');
 app.use(auth);
+const agent = require('./agent_middleware.js');
+app.use(agent);
 
 // Enable parsing request bodies
 app.use(express.json());

--- a/examples/node.js/routes/paymentorders.js
+++ b/examples/node.js/routes/paymentorders.js
@@ -164,7 +164,7 @@ const paymentOrderSchema = Joi.object().keys({
     }),
     disablePaymentMenu: Joi.boolean(),
     paymentToken: Joi.string(),
-    initiatingSystemUserAgent: Joi.string()
+    initiatingSystemUserAgent: Joi.string() //this is not part of the request and will be removed in the future
 });
 
 /**
@@ -229,7 +229,7 @@ module.exports.route = (req, res) => {
 
     preparePaymentOrder(paymentOrder);
 
-    post('/psp/paymentorders/', req.body, paymentOrder.userAgent)
+    post('/psp/paymentorders/', req.body)
         .then(pspResponse => {
             // payeeReference is our paymentId,
             // as set in preparePaymentOrder

--- a/examples/node.js/tests/patch.test.js
+++ b/examples/node.js/tests/patch.test.js
@@ -14,13 +14,14 @@ chai.should();
 
 const env = process.env;
 let headers = { 
-  Accept: 'application/json', 
-  [constants.apiKeyHeaderName]: [env["API_KEY"]],
-  [constants.accessTokenHeaderName]: "doot_doot",
+	"User-Agent": "NodeTestSuite/3.0",
+	Accept: 'application/json', 
+	[constants.apiKeyHeaderName]: [env["API_KEY"]],
+	[constants.accessTokenHeaderName]: "doot_doot",
 };
 
 function checkCredentials(res) {
-  chai.assert(res.status != 401, "Getting 401, is the credentials missing?\n" + res.text);
+	chai.assert(res.status != 401, "Getting 401, is the credentials missing?\n" + res.text);
 }
 
 function printResult(res) {
@@ -28,107 +29,103 @@ function printResult(res) {
 }
 
 describe('Patch Instrument v3', () => {
-  
-  it('Payment order should be patched with a new Instrument', (done) => {
 
-	const paymentOrder = JSON.parse(fs.readFileSync("tests/paymentOrderRequest_v3.json").toString());
-	paymentOrder.paymentorder.instrument = "CreditCard";
+	it('Payment order should be patched with a new Instrument', (done) => {
 
-	//paymentOrder.paymentorder.generateRecurrenceToken = true;
-  //paymentOrder.paymentorder.generateUnscheduledToken = true;
-  // note that tokens are not compatible with all instruments
+		const paymentOrder = JSON.parse(fs.readFileSync("tests/paymentOrderRequest_v3.json").toString());
+		paymentOrder.paymentorder.instrument = "CreditCard";
+
+		//paymentOrder.paymentorder.generateRecurrenceToken = true;
+	  	//paymentOrder.paymentorder.generateUnscheduledToken = true;
+	  	// note that tokens are not compatible with all instruments
 
 
-	chai.request(app)
-	  .post('/paymentorders')
-	  .set(headers)
-	  .send(paymentOrder)
-	  .end((err, res) => {
+	    chai.request(app)
+	    .post('/paymentorders')
+	    .set(headers)
+	    .send(paymentOrder)
+	    .end((err, res) => {
 
-		checkCredentials(res);
-		
-		res.should.have.status(200);
-		res.body.should.be.a('object');
+		  	checkCredentials(res);
 
-		const href = findOperation(res.body, "set-instrument").href;
-		if (!href) {
-			console.log("error! No operation!");
-		}
-
-		//Now patch this payment order!
-		let params = {
-			href: href,
-			paymentorder: {
-				operation: "SetInstrument",
-				instrument: "Swish"
-			}
-		};
-
-		chai.request(app)
-		  .patch('/patch')
-		  .set(headers)
-		  .send(params)
-		  .end((err, res) => {
-
-		  	//console.log(res.text) 
-		  	//console.log(err)
 		  	res.should.have.status(200);
+		  	res.body.should.be.a('object');
 
-			done();
+		  	const href = findOperation(res.body, "set-instrument").href;
+		  	if (!href) {
+		  		console.log("error! No operation!");
+		  	}
+
+			//Now patch this payment order!
+			let params = {
+				href: href,
+				paymentorder: {
+					operation: "SetInstrument",
+					instrument: "Swish"
+				}
+			};
+
+			chai.request(app)
+			.patch('/patch')
+			.set(headers)
+			.send(params)
+			.end((err, res) => {
+
+				//console.log(res.text) 
+				//console.log(err)
+				res.should.have.status(200);
+				done();
+			});
 		});
-	 });
-	
-  })
-  .timeout(15 * 1000);  //usually it never takes more than one second
+	})
+  	.timeout(15 * 1000);  //usually it never takes more than one second
 });
 
 describe('Patch Abort', () => {
-  
-  it('Payment order should be aborted', (done) => {
 
-	const paymentOrder = JSON.parse(fs.readFileSync("tests/paymentOrderRequest_v3.json").toString());
+	it('Payment order should be aborted', (done) => {
 
-	chai.request(app)
-	  .post('/paymentorders')
-	  .set(headers)
-	  .send(paymentOrder)
-	  .end((err, res) => {
-
-		checkCredentials(res);
-		
-		res.should.have.status(200);
-		res.body.should.be.a('object');
-
-		const href = findOperation(res.body, "abort").href;
-		if (!href) {
-			console.log("error! No operation!");
-		}
-
-		//Now patch this payment order!
-		let params = {
-			href: href,
-			paymentorder: {
-				operation: "Abort",
-				abortReason: "AbortedByUser"
-			}
-		};
+		const paymentOrder = JSON.parse(fs.readFileSync("tests/paymentOrderRequest_v3.json").toString());
 
 		chai.request(app)
-		  .patch('/patch')
-		  .set(headers)
-		  .send(params)
-		  .end((err, res) => {
+		.post('/paymentorders')
+		.set(headers)
+		.send(paymentOrder)
+		.end((err, res) => {
 
-		  	//console.log(res.text) 
-		  	//console.log(err)
-		  	res.should.have.status(200);
+			checkCredentials(res);
 
-			done();
+			res.should.have.status(200);
+			res.body.should.be.a('object');
+
+			const href = findOperation(res.body, "abort").href;
+			if (!href) {
+				console.log("error! No operation!");
+			}
+
+			//Now patch this payment order!
+			let params = {
+				href: href,
+				paymentorder: {
+					operation: "Abort",
+					abortReason: "AbortedByUser"
+				}
+			};
+
+			chai.request(app)
+			.patch('/patch')
+			.set(headers)
+			.send(params)
+			.end((err, res) => {
+
+				//console.log(res.text) 
+				//console.log(err)
+				res.should.have.status(200);
+				done();
+			});
 		});
-	 });
-	
-  })
-  .timeout(15 * 1000);  //usually it never takes more than one second
+	})
+  	.timeout(15 * 1000);  //usually it never takes more than one second
 });
 
 /*
@@ -146,7 +143,7 @@ describe('Verify and get tokens', () => {
 	  .send({ resource, expand })
 	  .end((err, res) => {
 
-	  	printResult(res)
+		printResult(res)
 
 			checkCredentials(res);
 			

--- a/examples/node.js/tests/paymentorder.test.js
+++ b/examples/node.js/tests/paymentorder.test.js
@@ -14,13 +14,14 @@ chai.should();
 
 const env = process.env;
 let headers = { 
-  Accept: 'application/json', 
-  [constants.apiKeyHeaderName]: [env["API_KEY"]],
-  [constants.accessTokenHeaderName]: "doot_doot",
+	"User-Agent": "NodeTestSuite/3.0",
+	Accept: 'application/json', 
+	[constants.apiKeyHeaderName]: [env["API_KEY"]],
+	[constants.accessTokenHeaderName]: "doot_doot",
 };
 
 function checkCredentials(res) {
-  chai.assert(res.status != 401, "Getting 401, is the credentials missing?\n" + res.text);
+	chai.assert(res.status != 401, "Getting 401, is the credentials missing?\n" + res.text);
 }
 
 function printResult(res) {
@@ -28,73 +29,70 @@ function printResult(res) {
 }
 
 describe('Post PaymentOrder v3', () => {
-  
-  it('Payment order should be accepted', (done) => {
 
-	const paymentOrder = JSON.parse(fs.readFileSync("tests/paymentOrderRequest_v3.json").toString());
+	it('Payment order should be accepted', (done) => {
 
-	chai.request(app)
-	  .post('/paymentorders')
-	  .set(headers)
-	  .send(paymentOrder)
-	  .end((err, res) => {
+		const paymentOrder = JSON.parse(fs.readFileSync("tests/paymentOrderRequest_v3.json").toString());
 
-		//console.log(res.text)
-		checkCredentials(res);
+		chai.request(app)
+		.post('/paymentorders')
+		.set(headers)
+		.send(paymentOrder)
+		.end((err, res) => {
 
-		res.should.have.status(200);
-		res.body.should.be.a('object');
-		done();
-	 });
-	
-  })
-  .timeout(15 * 1000);  //usually it never takes more than one second
+			//console.log(res.text)
+			checkCredentials(res);
+
+			res.should.have.status(200);
+			res.body.should.be.a('object');
+			done();
+		});
+	})
+  	.timeout(15 * 1000);  //usually it never takes more than one second
 });
 
 describe('Handle bad formatted PaymentOrder', () => {
-  
-  it('Payment order should NOT be accepted', (done) => {
 
-	let paymentOrder = JSON.parse(fs.readFileSync("tests/paymentOrderRequest_v3.json").toString());
-	paymentOrder.paymentorder.operation = "invalid setting";
-	chai.request(app)
-	  .post('/paymentorders')
-	  .set(headers)
-	  .send(paymentOrder)
-	  .end((err, res) => {
+	it('Payment order should NOT be accepted', (done) => {
 
-		//console.log(res.text)
+		let paymentOrder = JSON.parse(fs.readFileSync("tests/paymentOrderRequest_v3.json").toString());
+		paymentOrder.paymentorder.operation = "invalid setting";
+		chai.request(app)
+		.post('/paymentorders')
+		.set(headers)
+		.send(paymentOrder)
+		.end((err, res) => {
 
-		checkCredentials(res);
-		res.should.have.status(400);
-		res.body.should.be.a('object');
-		done();
-	 });
-  })
-  .timeout(15 * 1000);  //usually it never takes more than one second
+			//console.log(res.text)
+
+			checkCredentials(res);
+			res.should.have.status(400);
+			res.body.should.be.a('object');
+			done();
+		});
+	})
+	.timeout(15 * 1000);  //usually it never takes more than one second
 });
 
 describe('Post PaymentOrder v2', () => {
-  
-  it('Payment order should be accepted', (done) => {
 
-	const paymentOrder = JSON.parse(fs.readFileSync("tests/paymentOrderRequest_v2.json").toString());
-	chai.request(app)
-	  .post('/paymentorders')
-	  .set(headers)
-	  .send(paymentOrder)
-	  .end((err, res) => {
+	it('Payment order should be accepted', (done) => {
 
-		checkCredentials(res);
-		res.should.have.status(200);
-		res.body.should.be.a('object');
-		done();
-	 });
-	
-  })
+		const paymentOrder = JSON.parse(fs.readFileSync("tests/paymentOrderRequest_v2.json").toString());
+		chai.request(app)
+		.post('/paymentorders')
+		.set(headers)
+		.send(paymentOrder)
+		.end((err, res) => {
+
+			checkCredentials(res);
+			res.should.have.status(200);
+			res.body.should.be.a('object');
+			done();
+		});
+	})
   .timeout(15 * 1000);  //usually it never takes more than one second
 });
-
 
 
 /**
@@ -124,6 +122,7 @@ describe('Post PaymentOrder v3 with checkin', () => {
   .timeout(15 * 1000);  //usually it never takes more than one second
 });
 
+
 describe('Expand payer in a v3 payment order', () => {
   
   it('Payer should be expanded', (done) => {
@@ -131,15 +130,15 @@ describe('Expand payer in a v3 payment order', () => {
 	chai.request(app)
 	  .post("/expand") 
 	  .set(headers)
-	  .send({ resource: "/psp/paymentorders/d63f8079-01d9-499e-6f7d-08d9f03a45d6", expand: ["payer", "urls", "history"] })
+	  .send({ resource: "/psp/paymentorders/567ef38b-3704-444d-7082-08da05b8e84b", expand: ["paid", "failedAttempts", "failed", "history"] })
 	  .end((err, res) => {
 
-		printResult(res);
-		checkCredentials(res);
+			printResult(res);
+			checkCredentials(res);
 
-		res.should.have.status(200);
-		res.body.should.be.a('object');
-		done();
+			res.should.have.status(200);
+			res.body.should.be.a('object');
+			done();
 	 });
 	
   })

--- a/examples/node.js/util/networking.js
+++ b/examples/node.js/util/networking.js
@@ -44,14 +44,14 @@ const getJsonOrThrowProblem = async (response) => {
  * @returns {object} Promise whose then() gets a single parameter that is the
  * server response as a parsed object representing the JSON response content.
  */
-const request = async (method, path, body, userAgent) => {
+const request = async (method, path, body) => {
     const baseUrl = process.env.SWEDBANKPAY_SERVER_BASE_URL ||
         global.config.payexBaseUrl;
     const url = `${baseUrl}${path}`;
-    return await requestUrl(method, url, body, userAgent);
+    return await requestUrl(method, url, body);
 }
 
-async function requestUrl(method, url, body, userAgent) {
+async function requestUrl(method, url, body) {
     const opts = {
         method: method,
         compress: false,
@@ -60,8 +60,8 @@ async function requestUrl(method, url, body, userAgent) {
             'Authorization': `Bearer ${global.config.merchantToken}`
         }
     };
-    if (userAgent) {
-        opts.headers["User-Agent"] = userAgent
+    if (global.userAgent) {
+        opts.headers["User-Agent"] = global.userAgent;
     }
 
     if (body) {
@@ -95,8 +95,8 @@ async function requestUrl(method, url, body, userAgent) {
  * @returns {object} Promise whose then() gets a single parameter that is the
  * server response as a parsed object representing the JSON response content.
  */
-module.exports.post = async (path, body, userAgent) => {
-    return await request('post', path, body, userAgent);
+module.exports.post = async (path, body) => {
+    return await request('post', path, body);
 };
 
 /**


### PR DESCRIPTION
Send in the User-Agent as a regular http header in every call to Swedbank, relaying the header from the caller so we always send in the current value.

Also tidied up the tests a bit.