### PR TITLE
Changed backend user agent to match with documentation

### DIFF
--- a/examples/node.js/agent_middleware.js
+++ b/examples/node.js/agent_middleware.js
@@ -1,7 +1,8 @@
 'use strict';
 
 /**
- * User-agent middleware. We need to supply the SDK version to the system in every request. 
+ * User-agent middleware. We need to supply the SDK version to the system in every request.
+ * More info here: https://developer.stage.swedbankpay.com/introduction#user-agent
  *
  * @param {object} req our Express request object
  * @param {object} res our Express response object
@@ -10,10 +11,12 @@
 const agent = (req, res, next) => {
 
     const userAgent = req.headers["user-agent"] || req.headers["User-Agent"] || req.headers["User-agent"];
-    if (userAgent && userAgent.includes("SwedbankPaySDK")) {
-        // always give information on which SDK is used, just forward it from the client to Swedbank.
-        //console.log(`userAgent: ${userAgent}`);
-        global.userAgent = userAgent;
+    global.clientUserAgent = userAgent;
+    const position = userAgent.lastIndexOf("/");
+    if (userAgent && position > 0 && userAgent.includes("SwedbankPaySDK")) {
+        // always give information on which SDK is used, forward it from the client to Swedbank, but make sure they know it's from the backend.
+        const sdkVersion = userAgent.substring(position + 1);
+        global.userAgent = "SwedbankPaySDK-Node/" + sdkVersion;
     }
     next();
 };


### PR DESCRIPTION
The backend reports the SDK version in the userAgent-header, but still sends in its own values. Previously it just re-sent the client’s userAgent.