### PR TITLE
mock DB id bug

### DIFF
--- a/examples/node.js/database/database.js
+++ b/examples/node.js/database/database.js
@@ -2,12 +2,7 @@
 
 module.exports = class Database {
     constructor() {
-        console.log(`Creating Database instance`);
-
-        // Initialize our fake ID sequence from a random integer at DB creation, so it won't collide with multiple instances queried at the same time.
         
-        this.idSequence = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
-
         // Contains our "database" as an in-memory map ID => purchaseData
         this.db = { pspId: {} };
     }
@@ -20,8 +15,8 @@ module.exports = class Database {
      * @returns {number} ID allocated for the new purchase
      */
     insertPurchase(purchase) {
-        // Get an ID for the purchase from our ID sequence
-        const id = this.idSequence++;
+        // Get an ID for the purchase by generating a random ID. 
+        const id = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 
         this.db[id] = purchase;
 

--- a/examples/node.js/database/database.js
+++ b/examples/node.js/database/database.js
@@ -4,12 +4,14 @@ module.exports = class Database {
     constructor() {
         console.log(`Creating Database instance`);
 
-        // Initialize our fake ID sequence from the system clock at DB creation
-        this.idSequence = new Date().getTime();
+        // Initialize our fake ID sequence from a random integer at DB creation, so it won't collide with multiple instances queried at the same time.
+        
+        this.idSequence = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 
         // Contains our "database" as an in-memory map ID => purchaseData
         this.db = { pspId: {} };
     }
+    
 
     /**
      * Inserts a new purchase into the database.

--- a/examples/node.js/package.json
+++ b/examples/node.js/package.json
@@ -21,7 +21,7 @@
     "start": "node app.js",
     "dev": "nodemon app.js",
     "start-dev": "nodemon app.js",
-    "test": "mocha tests/*.js --exit"
+    "test": "export PORT=8081; mocha tests/*.js --exit"
   },
   "keywords": [
     "node",


### PR DESCRIPTION
Sometimes tests fail due to duplicate ids, due to how they are generated on the backend. This avoids using ids that are likely to be similar to other instances.